### PR TITLE
Fixing the implementation of msigma

### DIFF
--- a/src/singleLayer.jl
+++ b/src/singleLayer.jl
@@ -11,7 +11,7 @@ where K,b are trainable weights
 struct SingleLayer
 end
 
-mσ(x::AbstractArray{R}) where R<:Real = abs.(x)+log.(R(1)+exp.(-R(2)*abs.(x)))
+mσ(x::AbstractArray{R}) where R<:Real = abs.(x)+log.(R(1) .+ exp.(-R(2)*abs.(x)))
 mdσ(x::AbstractArray{R}) where R<:Real = tanh.(x)
 md2σ(x::AbstractArray{R}) where R<:Real = one(eltype(x)) .- tanh.(x).^2
 


### PR DESCRIPTION
R(1) + x doesn't work if x is an array.
Suggested fix: Use broadcasting to add R(1) to each element of` x, i.e., 
R(1) .+ x

Sample x
```
julia> x = Flux.Tracker.collect(fill(1.0, 2, 256))
Tracked 2×256 Array{Float64,2}:
 1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  …  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0      
 1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0     1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0  1.0      
```
Original:
```
julia> mσ(x::AbstractArray{R}) where R<:Real = abs.(x)+log.(R(1)+exp.(-R(2)*abs.(x)))
mσ (generic function with 1 method)

julia> mσ(x)
ERROR: MethodError: no method matching +(::Float64, ::TrackedArray{…,Array{Float64,2}})
Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...) at operators.jl:529
  +(::Float64, ::Float64) at float.jl:401
  +(::AbstractFloat, ::Bool) at bool.jl:106
  ...
Stacktrace:
 [1] mσ(::TrackedArray{…,Array{Float64,2}}) at .\none:1
 [2] top-level scope at none:0

```
Suggested:
```
julia> mσ(x::AbstractArray{R}) where R<:Real = abs.(x)+log.(R(1) .+ exp.(-R(2)*abs.(x)))
mσ (generic function with 1 method)

julia> mσ(x)
Tracked 2×256 Array{Float64,2}:
 1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  …  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693   
 1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693     1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693  1.12693   
```